### PR TITLE
Attempt to fix "JS objects may not be shared across threads" error when ...

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -113,6 +113,8 @@ Stream.prototype =
   }
 , _connect: function _connect() {
     let transport = this._transport
+    let threadManager = Cc["@mozilla.org/thread-manager;1"].
+        getService(Ci.nsIThreadManager);
 
     this._rawOutput = transport.openOutputStream(0, 0, 0)
     this._rawInput = transport.openInputStream(0, 0, 0)
@@ -124,7 +126,7 @@ Stream.prototype =
     }, null)
 
     transport.setEventSink(
-      { onTransportStatus: this._onStatus.bind(this) }, null
+      { onTransportStatus: this._onStatus.bind(this)}, threadManager.currentThread
     )
   }
 , _onStatus: function _onStatus(transport, status, progress, total) {


### PR DESCRIPTION
...connecting.

When aEventTarget in setEventSink is set to null (any thread) following error occurs:
"Attempt to use JS function on a different thread calling nsITransportEventSink.onTransportStatus.
JS objects may not be shared across threads."
Setting aEventTarget to current thread fixes this issue.

Signed-off-by: Mischa Zurke mischa.z@gmail.com
