### PR TITLE
fix redundant increment of guid 

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -37,7 +37,7 @@ function Stream() {
   let guid = ++ GUID
   return streams[guid] = 
   { __proto__: Stream.prototype
-  , _guid: ++ guid
+  , _guid: guid
   }
 }
 Stream.prototype = 


### PR DESCRIPTION
This could be a potential source of memory leaks on extension unload. (I assume that's the only reason guids are issued in the first place?)
